### PR TITLE
Add env yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,28 @@
+name: gmso-showcase
+channels:
+  - conda-forge
+  - mosdef
+  - bioconda
+  - omnia
+dependencies:
+  - python=3.7
+  - numpy
+  - sympy
+  - unyt >= 2.4
+  - boltons
+  - lxml
+  - pytest
+  - mbuild >= 0.10.6
+  - openbabel >= 3.0
+  - foyer
+  - gsd >= 2.0
+  - parmed
+  - pytest-cov
+  - codecov
+  - pip
+  - matplotlib
+  - py3Dmol
+  - pydantic
+  - nodejs>=10
+  - jupyterlab
+  - jupyter-offlinenotebook

--- a/environment.yml
+++ b/environment.yml
@@ -26,3 +26,5 @@ dependencies:
   - nodejs>=10
   - jupyterlab
   - jupyter-offlinenotebook
+  - pip:
+    - "--editable=git+https://github.com/mosdef-hub/gmso.git#egg=gmso-master"


### PR DESCRIPTION
Currently our repo is lacking a controlled way to build an environment
for all of us to use while developing these notebooks.

This provides a conda environment.yml file defining such a environment,
including a source pip installation of gmso.